### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/src/components/TimelineView.jsx
+++ b/src/components/TimelineView.jsx
@@ -554,7 +554,7 @@ const TimelineView = forwardRef(function TimelineView({
     const fallbackFont = '"Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
     let resolvedFont;
     if (fileFontSetting && String(fileFontSetting).toLowerCase() !== "default") {
-      const safeName = String(fileFontSetting).replace(/"/g, '\\"');
+      const safeName = String(fileFontSetting).replace(/([\\"])/g, "\\$1");
       resolvedFont = `"${safeName}", ${fallbackFont}`;
     } else {
       resolvedFont = getComputedStyle(document.documentElement).getPropertyValue("--app-font-family").trim() || fallbackFont;


### PR DESCRIPTION
Potential fix for [https://github.com/sreegjl/timelines/security/code-scanning/3](https://github.com/sreegjl/timelines/security/code-scanning/3)

Use a robust escaping step that handles both backslashes and double quotes before embedding `fileFontSetting` into a quoted CSS string.

Best fix in this snippet:
- In `src/components/TimelineView.jsx`, replace the current one-pass quote escaping on line 557 with a regex that escapes **both** `\` and `"` globally.
- Keep existing functionality (still wrapping in `"` and preserving fallback font chain).

Concrete change:
- Replace:
  - `String(fileFontSetting).replace(/"/g, '\\"')`
- With:
  - `String(fileFontSetting).replace(/([\\"])/g, "\\$1")`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
